### PR TITLE
✨ Setter opp et forslag til en løsning der vi ignorer sensoren uten recent trafikk

### DIFF
--- a/client/src/main/java/pro/panopticon/client/sensor/impl/SuccessrateSensor.java
+++ b/client/src/main/java/pro/panopticon/client/sensor/impl/SuccessrateSensor.java
@@ -93,13 +93,13 @@ public class SuccessrateSensor implements Sensor {
         return eventQueues.entrySet().stream()
                 .map((Map.Entry<AlertInfo, CircularFifoQueue<Tick>> e) -> {
                     AlertInfo alertInfo = e.getKey();
-                    List<Tick> events = new ArrayList<>(e.getValue());
-                    int all = events.size();
-                    long success = events.stream().filter(tick -> tick.event == Event.SUCCESS).count();
-                    long failure = events.stream().filter(tick -> tick.event == Event.FAILURE).count();
+                    List<Tick> ticks = new ArrayList<>(e.getValue());
+                    int all = ticks.size();
+                    long success = ticks.stream().filter(tick -> tick.event == Event.SUCCESS).count();
+                    long failure = ticks.stream().filter(tick -> tick.event == Event.FAILURE).count();
                     double percentFailureDouble = all > 0 ? (double) failure / (double) all : 0;
                     boolean enoughDataToAlert = all == numberToKeep;
-                    boolean allTicksAreTooOld = allTicksAreTooOld(events);
+                    boolean allTicksAreTooOld = allTicksAreTooOld(ticks);
                     String display = String.format("Last %s calls: %s success, %s failure (%.2f%% failure)%s%s",
                             Integer.min(all, numberToKeep),
                             success,

--- a/client/src/main/java/pro/panopticon/client/sensor/impl/SuccessrateSensor.java
+++ b/client/src/main/java/pro/panopticon/client/sensor/impl/SuccessrateSensor.java
@@ -90,7 +90,7 @@ public class SuccessrateSensor implements Sensor {
                     double percentFailureDouble = all > 0 ? (double) failure / (double) all : 0;
                     boolean enoughDataToAlert = all == numberToKeep;
                     boolean allTicksAreTooOld = allTicksAreTooOld(events);
-                    String display = String.format("Last %s calls: %s success, %s failure (%.2f%% failure)%s",
+                    String display = String.format("Last %s calls: %s success, %s failure (%.2f%% failure)%s%s",
                             Integer.min(all, numberToKeep),
                             success,
                             all - success,
@@ -98,15 +98,15 @@ public class SuccessrateSensor implements Sensor {
                             enoughDataToAlert ? "" : " - not enough calls to report status yet",
                             allTicksAreTooOld ? "" : " - all ticks are outdated"
                     );
-                    String status = decideStatus(enoughDataToAlert, percentFailureDouble, events);
+                    String status = decideStatus(enoughDataToAlert, percentFailureDouble, allTicksAreTooOld);
                     return new Measurement(alertInfo.getSensorKey(), status, display, new Measurement.CloudwatchValue(percentFailureDouble * 100, StandardUnit.Percent), alertInfo.getDescription());
                 })
                 .collect(toList());
     }
 
-    private String decideStatus(boolean enoughDataToAlert, double percentFailure, List<Tick> events) {
+    private String decideStatus(boolean enoughDataToAlert, double percentFailure, boolean allTicksAreTooOld) {
         if (!enoughDataToAlert) return "INFO";
-        if (allTicksAreTooOld(events)) return "INFO";
+        if (allTicksAreTooOld) return "INFO";
         if (errorLimit != null && percentFailure >= errorLimit) return "ERROR";
         if (warnLimit != null && percentFailure >= warnLimit) return "WARN";
         return "INFO";

--- a/client/src/main/java/pro/panopticon/client/util/NowSupplier.java
+++ b/client/src/main/java/pro/panopticon/client/util/NowSupplier.java
@@ -1,0 +1,7 @@
+package pro.panopticon.client.util;
+
+import java.time.LocalDateTime;
+
+public interface NowSupplier {
+    LocalDateTime now();
+}

--- a/client/src/main/java/pro/panopticon/client/util/NowSupplierImpl.java
+++ b/client/src/main/java/pro/panopticon/client/util/NowSupplierImpl.java
@@ -1,0 +1,12 @@
+package pro.panopticon.client.util;
+
+import java.time.LocalDateTime;
+
+public class NowSupplierImpl implements NowSupplier {
+
+    @Override
+    public LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+
+}

--- a/client/src/test/java/pro/panopticon/client/sensor/impl/SuccessrateSensorTest.java
+++ b/client/src/test/java/pro/panopticon/client/sensor/impl/SuccessrateSensorTest.java
@@ -1,6 +1,5 @@
 package pro.panopticon.client.sensor.impl;
 
-import org.hamcrest.core.StringContains;
 import org.junit.Test;
 import pro.panopticon.client.model.Measurement;
 


### PR DESCRIPTION
I dag har vi en liten svakhet med successrate-sensoren. Hvis tjenesten som bruker den ikke har noe særlig trafikk, så blir alarmene hengende veldig lenge igjen. Dette kan være litt plagsomt og forstyrrende for vakta, og for de som følger opp incidents. Tester ut en implementasjon som gjør følgende:

* Alle ticks registreres med når de ble laget.
* Når man gjør en measurement, så sjekker om det er registrert noen
ticks den siste timen i det hele tatt. Hvis ikke, ikke sett status
til alarm (uansett!).

Det som ligger til grunn her er følgende:
* Hvis en sensor ikke har hatt trafikk, la oss si siste 60 minutter, så trenger vi ikke en aktiv alarm på den. 
* Når et nytt kall eventuelt feiler, så vil det genereres en alarm igjen. 

### Eksempel på en "vrang" alarm
![image](https://user-images.githubusercontent.com/1188754/91553129-3332f880-e92d-11ea-902d-481bb834c72b.png)


### Diskusjonspunkter
* Hva tenker dere om en slik feature i seg selv? Noen scenarioer der dette ikke er heldig?
* Hva bør en eventuell grenseverdi være? 60 minutter, eller kanskje lengre?

### Helt til slutt

En liten testenøtt for de som liker sånt. Hvordan ville dere skrevet enhetstester for denne implementasjonen? Her opererer vi med tid som er litt kronglete å mocke opp. Man kan jo bruke powermockito og lignende, men det føles litt tungvint og gammeldags. Man kunne også sendt med et eget objekt i konstruktøren som er ansvarlig for å beregne tid, som man kunne mocket opp. Men da endrer man signaturen på denne klassen som blir eksponert ut.

![image](https://user-images.githubusercontent.com/1188754/91553534-dd128500-e92d-11ea-8292-2f0d09674c82.png)
