### PR TITLE
✨ Introduser mulighet for å sende med dimension

### DIFF
--- a/client/src/main/java/pro/panopticon/client/awscloudwatch/CloudwatchClient.java
+++ b/client/src/main/java/pro/panopticon/client/awscloudwatch/CloudwatchClient.java
@@ -11,9 +11,12 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import pro.panopticon.client.model.MetricDimension;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
@@ -79,6 +82,7 @@ public class CloudwatchClient {
         private Double value;
         private StandardUnit unit;
         private Date date;
+        private List<MetricDimension> dimensions = new ArrayList<>();
 
         public CloudwatchStatistic(String key, Double value, StandardUnit unit, java.util.Date date) {
             this.key = key;
@@ -95,13 +99,28 @@ public class CloudwatchClient {
             this(key, value, StandardUnit.Count, new Date());
         }
 
+        public CloudwatchStatistic withDimensions(List<MetricDimension> dimensions) {
+            this.dimensions = dimensions;
+            return this;
+        }
+
         public MetricDatum toMetricsDatum() {
             MetricDatum metricDatum = new MetricDatum();
             metricDatum.setMetricName(key);
             metricDatum.setTimestamp(date);
             metricDatum.setUnit(unit);
             metricDatum.setValue(value);
+            metricDatum.setDimensions(mapToAwsDimension());
             return metricDatum;
+        }
+
+        private List<com.amazonaws.services.cloudwatch.model.Dimension> mapToAwsDimension() {
+            return dimensions.stream().map(dimension -> {
+                com.amazonaws.services.cloudwatch.model.Dimension awsDimension = new com.amazonaws.services.cloudwatch.model.Dimension();
+                awsDimension.setName(dimension.name);
+                awsDimension.setValue(dimension.value);
+                return awsDimension;
+            }).collect(Collectors.toList());
         }
     }
 }

--- a/client/src/main/java/pro/panopticon/client/eventlogger/AbstractEventLogger.java
+++ b/client/src/main/java/pro/panopticon/client/eventlogger/AbstractEventLogger.java
@@ -101,7 +101,7 @@ public class AbstractEventLogger implements Sensor {
             cloudwatchClient.sendStatistics(namespace, statistics);
         }
 
-        return counts.entrySet().stream()
+        return countsToProcess.entrySet().stream()
                 .map(e -> new Measurement("audit." + e.getKey(), "INFO", "Last minute: " + e.getValue().doubleValue(), ""))
                 .collect(toList());
     }

--- a/client/src/main/java/pro/panopticon/client/eventlogger/AbstractEventLogger.java
+++ b/client/src/main/java/pro/panopticon/client/eventlogger/AbstractEventLogger.java
@@ -4,12 +4,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pro.panopticon.client.awscloudwatch.CloudwatchClient;
 import pro.panopticon.client.awscloudwatch.HasCloudwatchConfig;
+import pro.panopticon.client.model.MetricDimension;
 import pro.panopticon.client.model.Measurement;
 import pro.panopticon.client.sensor.Sensor;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.DoubleAdder;
@@ -23,7 +26,8 @@ public class AbstractEventLogger implements Sensor {
     private final Logger LOG = LoggerFactory.getLogger(this.getClass());
     private final String namespace;
 
-    ConcurrentMap<String, DoubleAdder> counts = new ConcurrentHashMap<>();
+    private ConcurrentMap<String, DoubleAdder> counts = new ConcurrentHashMap<>();
+    private Vector<CloudwatchClient.CloudwatchStatistic> ticksWithDimensions = new Vector<>();
 
     private HasCloudwatchConfig hasCloudwatchConfig;
     private CloudwatchClient cloudwatchClient;
@@ -61,6 +65,22 @@ public class AbstractEventLogger implements Sensor {
         performTick(event, count);
     }
 
+    public void tick(HasEventInfo event, MetricDimension... dimensions) {
+        CloudwatchClient.CloudwatchStatistic statistics = new CloudwatchClient.CloudwatchStatistic(
+                event.getEventName(),
+                1.0
+        ).withDimensions(Arrays.asList(dimensions));
+        ticksWithDimensions.add(statistics);
+    }
+
+    public void tick(HasEventInfo event, double count, MetricDimension... dimensions) {
+        CloudwatchClient.CloudwatchStatistic statistics = new CloudwatchClient.CloudwatchStatistic(
+                event.getEventName(),
+                count
+        ).withDimensions(Arrays.asList(dimensions));
+        ticksWithDimensions.add(statistics);
+    }
+
     private void performLog(HasEventInfo event, String... logappends) {
         LOG.info("AUDIT EVENT - [" + event.getEventType() + "] - [" + event.getEventName() + "] - " + Stream.of(logappends).map(s -> "[" + s + "]").collect(joining(" - ")));
     }
@@ -71,18 +91,33 @@ public class AbstractEventLogger implements Sensor {
 
     @Override
     public List<Measurement> measure() {
-        ConcurrentMap<String, DoubleAdder> mapToProcess = counts;
-        counts = new ConcurrentHashMap<>();
+        ConcurrentMap<String, DoubleAdder> countsToProcess = this.counts;
+        Vector<CloudwatchClient.CloudwatchStatistic> countsWithDimensionToProcess = this.ticksWithDimensions;
+        resetTicks();
 
-        if (cloudwatchClient != null && hasCloudwatchConfig != null && hasCloudwatchConfig.auditeventStatisticsEnabled()) {
-            List<CloudwatchClient.CloudwatchStatistic> statistics = mapToProcess.entrySet().stream()
-                    .map(e -> new CloudwatchClient.CloudwatchStatistic(e.getKey(), e.getValue().doubleValue()))
-                    .collect(toList());
+        if (statisticsEnabled()) {
+            List<CloudwatchClient.CloudwatchStatistic> statistics = createCountStatistics(countsToProcess);
+            statistics.addAll(countsWithDimensionToProcess);
             cloudwatchClient.sendStatistics(namespace, statistics);
         }
 
-        return mapToProcess.entrySet().stream()
+        return counts.entrySet().stream()
                 .map(e -> new Measurement("audit." + e.getKey(), "INFO", "Last minute: " + e.getValue().doubleValue(), ""))
+                .collect(toList());
+    }
+
+    private boolean statisticsEnabled() {
+        return cloudwatchClient != null && hasCloudwatchConfig != null && hasCloudwatchConfig.auditeventStatisticsEnabled();
+    }
+
+    private void resetTicks() {
+        this.counts = new ConcurrentHashMap<>();
+        this.ticksWithDimensions = new Vector<>();
+    }
+
+    private List<CloudwatchClient.CloudwatchStatistic> createCountStatistics(ConcurrentMap<String, DoubleAdder> countsToProcess) {
+        return countsToProcess.entrySet().stream()
+                .map(e -> new CloudwatchClient.CloudwatchStatistic(e.getKey(), e.getValue().doubleValue()))
                 .collect(toList());
     }
 }

--- a/client/src/main/java/pro/panopticon/client/model/MetricDimension.java
+++ b/client/src/main/java/pro/panopticon/client/model/MetricDimension.java
@@ -1,0 +1,21 @@
+package pro.panopticon.client.model;
+
+public class MetricDimension {
+    public final String name;
+    public final String value;
+
+    private static final String PLATFORM_DIMENSION_NAME = "Platform";
+
+    private MetricDimension(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public static MetricDimension platformDimension(String value) {
+        return new MetricDimension(PLATFORM_DIMENSION_NAME, value);
+    }
+
+    public static MetricDimension customDimension(String key, String value) {
+        return new MetricDimension(key, value);
+    }
+}


### PR DESCRIPTION
### Bakgrunn 

[AWS Metrics ](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html)støtter muligheten for å sende med dimensjoner på metrikker. Dette lar deg f.eks legge inn plattform som en dimensjon som gjør at vi enklere kan gjøre spørringer spesifikt på plattform.

Fra dokumentasjonen: 

_A dimension is a name/value pair that is part of the identity of a metric. You can assign up to 10 dimensions to a metric._

_Every metric has specific characteristics that describe it, and you can think of dimensions as categories for those characteristics. Dimensions help you design a structure for your statistics plan. Because dimensions are part of the unique identifier for a metric, whenever you add a unique name/value pair to one of your metrics, you are creating a new variation of that metric._

_AWS services that send data to CloudWatch attach dimensions to each metric. You can use dimensions to filter the results that CloudWatch returns. For example, you can get statistics for a specific EC2 instance by specifying the InstanceId dimension when you search for metrics._

_For metrics produced by certain AWS services, such as Amazon EC2, CloudWatch can aggregate data across dimensions. For example, if you search for metrics in the AWS/EC2 namespace but do not specify any dimensions, CloudWatch aggregates all data for the specified metric to create the statistic that you requested. CloudWatch does not aggregate across dimensions for your custom metrics.__

### Use-case

Vi kan bruke dette til f.eks få metrikker som skiller på plattform (web, ios/android) eller andre dimensjoner man vil skille metrikker på. Dimensjoner tillater da lynkjappe spørringer. Eksempel fra itinerary:

![image](https://user-images.githubusercontent.com/1188754/98348617-46430280-2019-11eb-9371-d829e4558326.png)


### Nye public metoder i panopticon

```java
public void tick(HasEventInfo event, MetricDimension... dimensions) 
```

```java
public void tick(HasEventInfo event, double count, MetricDimension... dimensions)
```

For å lage en MetricDimension har jeg foreløpig laget to statiske factory-metoder:

```java
    public static MetricDimension platformDimension(String value) {
        return new MetricDimension(PLATFORM_DIMENSION_NAME, value);
    }

    public static MetricDimension customDimension(String key, String value) {
        return new MetricDimension(key, value);
    }
```

### Eksempel fra konsument
```java
        EventLogger.INSTANCE.tick(
            TravelPlannerEvent.TRAVEL_PLANNER_SEARCH_SUBMITTED,
            MetricDimension.platformDimension(clientInfo.terminalTypeEnum.name)
        )
```

### Teknisk løsning
Lager en ny Vector som holder styr på disse eventene.