### PR TITLE
🥅 Gjør dekoderen mer robust og logg feilmeldinger til konsollen

### DIFF
--- a/frontend/App/Subscriptions.elm
+++ b/frontend/App/Subscriptions.elm
@@ -1,11 +1,11 @@
 module App.Subscriptions exposing (subscriptions)
 
-import App.Model exposing (..)
 import App.Messages exposing (..)
-import Nav.Model exposing (Page(..))
+import App.Model exposing (..)
 import Detail.Subscriptions
+import Nav.Model exposing (Page(..))
+import Ports
 import Time exposing (second)
-import Auth exposing (loginResult)
 
 
 subscriptions : Model -> Sub Msg
@@ -16,17 +16,17 @@ subscriptions model =
 
         subs =
             [ refreshSub
-            , loginResult LoginResult
+            , Ports.loginResult LoginResult
             ]
     in
-        case model.page of
-            Component _ _ _ _ ->
-                let
-                    detailSub =
-                        Sub.map DetailMsg <|
-                            Detail.Subscriptions.subscriptions model.detail model.appState.url
-                in
-                    Sub.batch <| detailSub :: subs
+    case model.page of
+        Component _ _ _ _ ->
+            let
+                detailSub =
+                    Sub.map DetailMsg <|
+                        Detail.Subscriptions.subscriptions model.detail model.appState.url
+            in
+            Sub.batch <| detailSub :: subs
 
-            _ ->
-                Sub.batch subs
+        _ ->
+            Sub.batch subs

--- a/frontend/App/Update.elm
+++ b/frontend/App/Update.elm
@@ -3,11 +3,11 @@ module App.Update exposing (update)
 import App.Messages exposing (..)
 import App.Model exposing (..)
 import Components.Update
-import Detail.Update
 import Detail.Model
-import Nav.Requests exposing (getSystemStatus, getDetails)
+import Detail.Update
 import Nav.Model exposing (..)
-import Auth exposing (login)
+import Nav.Requests exposing (getDetails, getSystemStatus)
+import Ports
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -19,8 +19,10 @@ update msg model =
         GetSystemStatus ->
             ( model, getSystemStatus model.appState.url model.appState.token )
 
-        SystemStatus (Err _) ->
-            ( model, Cmd.none )
+        SystemStatus (Err err) ->
+            ( model
+            , Ports.log ("Klarte ikke å dekode kallet mot /status: " ++ toString err)
+            )
 
         SystemStatus (Ok components) ->
             ( { model | components = components }, Cmd.none )
@@ -30,7 +32,7 @@ update msg model =
                 componentsModel =
                     Components.Update.update componentsMsg model.components
             in
-                ( { model | components = componentsModel }, Cmd.none )
+            ( { model | components = componentsModel }, Cmd.none )
 
         DetailMsg detailMsg ->
             let
@@ -40,10 +42,10 @@ update msg model =
                 mappedCmd =
                     Cmd.map DetailMsg cmd
             in
-                ( { model | detail = detailModel }, mappedCmd )
+            ( { model | detail = detailModel }, mappedCmd )
 
         Login ->
-            ( setToken Nothing model.appState |> setAppState model, login () )
+            ( setToken Nothing model.appState |> setAppState model, Ports.login () )
 
         LoginResult token ->
             ( setToken (Just token) model.appState |> setAppState model
@@ -67,16 +69,16 @@ updatePage page m =
         model =
             leftPage m.page m
     in
-        case page of
-            Components as page ->
-                ( { model | page = page }, getSystemStatus model.appState.url model.appState.token )
+    case page of
+        Components as page ->
+            ( { model | page = page }, getSystemStatus model.appState.url model.appState.token )
 
-            (Component env system component server) as page ->
-                let
-                    cmd =
-                        Cmd.map DetailMsg <| getDetails model.appState.url model.appState.token env system component server
-                in
-                    ( { model | page = page }, cmd )
+        (Component env system component server) as page ->
+            let
+                cmd =
+                    Cmd.map DetailMsg <| getDetails model.appState.url model.appState.token env system component server
+            in
+            ( { model | page = page }, cmd )
 
 
 leftPage : Page -> Model -> Model

--- a/frontend/Auth.elm
+++ b/frontend/Auth.elm
@@ -1,7 +1,0 @@
-port module Auth exposing (..)
-
-
-port login : () -> Cmd msg
-
-
-port loginResult : (String -> msg) -> Sub msg

--- a/frontend/Component/Decoder.elm
+++ b/frontend/Component/Decoder.elm
@@ -1,19 +1,19 @@
 module Component.Decoder exposing (decoder)
 
 import Component.Model exposing (..)
-import Json.Decode exposing (Decoder, succeed, string, at, andThen, field)
-import Json.Decode.Extra exposing ((|:))
+import Json.Decode exposing (Decoder, andThen, at, field, string, succeed)
+import Json.Decode.Extra exposing ((|:), withDefault)
 
 
 decoder : Decoder Model
 decoder =
     succeed Model
-        |: (field "environment" string)
-        |: (field "system" string)
-        |: (field "component" string)
-        |: (field "server" string)
-        |: (field "overallStatus" string |> andThen decodeStatus)
-        |: (at [ "links", "details" ] string)
+        |: field "environment" maybeString
+        |: field "system" maybeString
+        |: field "component" maybeString
+        |: field "server" maybeString
+        |: (field "overallStatus" maybeString |> andThen decodeStatus)
+        |: at [ "links", "details" ] maybeString
 
 
 decodeStatus : String -> Decoder Status
@@ -30,3 +30,8 @@ decodeStatus status =
 
         _ ->
             succeed Error
+
+
+maybeString : Decoder String
+maybeString =
+    withDefault "null" string

--- a/frontend/Detail/Update.elm
+++ b/frontend/Detail/Update.elm
@@ -1,8 +1,9 @@
 module Detail.Update exposing (update)
 
-import Detail.Model exposing (..)
 import Detail.Messages exposing (..)
+import Detail.Model exposing (..)
 import Nav.Requests exposing (getDetails)
+import Ports
 
 
 update : Maybe String -> Msg -> Model -> ( Model, Cmd Msg )
@@ -16,10 +17,12 @@ update token msg model =
                 request =
                     getDetails baseUrl token model.environment model.system model.component model.server
             in
-                ( model, request )
+            ( model, request )
 
-        Get (Err _) ->
-            ( model, Cmd.none )
+        Get (Err err) ->
+            ( model
+            , Ports.log ("Klarte ikke å dekode detaljer-kallet: " ++ toString err)
+            )
 
         Get (Ok metrics) ->
             ( metrics, Cmd.none )

--- a/frontend/Main.elm
+++ b/frontend/Main.elm
@@ -1,16 +1,16 @@
 module Main exposing (..)
 
-import Navigation
-import App.Subscriptions exposing (subscriptions)
 import App.Messages exposing (..)
 import App.Model exposing (..)
+import App.Subscriptions exposing (subscriptions)
 import App.Update exposing (update)
 import App.View exposing (view)
 import Components.Model
 import Detail.Model
-import Nav.Nav exposing (hashParser, toHash)
 import Nav.Model exposing (Page)
-import Auth exposing (login)
+import Nav.Nav exposing (hashParser, toHash)
+import Navigation
+import Ports
 
 
 initModel : AppState -> Page -> Model
@@ -28,9 +28,9 @@ init flags location =
             toAppState flags
 
         initialCommand =
-            Maybe.withDefault (login ()) <| Maybe.map (\_ -> Navigation.newUrl <| toHash page) appState.token
+            Maybe.withDefault (Ports.login ()) <| Maybe.map (\_ -> Navigation.newUrl <| toHash page) appState.token
     in
-        ( initModel appState page, initialCommand )
+    ( initModel appState page, initialCommand )
 
 
 toAppState : Flags -> AppState
@@ -42,6 +42,7 @@ toMaybe : String -> Maybe String
 toMaybe s =
     if s == "" then
         Nothing
+
     else
         Just s
 

--- a/frontend/Ports.elm
+++ b/frontend/Ports.elm
@@ -1,0 +1,15 @@
+port module Ports exposing (..)
+
+
+port login : () -> Cmd msg
+
+
+port loginResult : (String -> msg) -> Sub msg
+
+
+log : String -> Cmd msg
+log message =
+    logPort message
+
+
+port logPort : String -> Cmd msg

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,6 +12,6 @@ Needs the following things things installed to build:
 
 - `npm i`
 - `cp config-example.json config.json`
-- Edit the values in `config.json`
+- Edit the values in `config.json` (these can  be found in the `nsbno/admin` repository)
 - `npm run watch` (answer yes to all questions)
 - Open your browser at http://localhost:8000/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "tmpl-cli": "^0.1.2"
   },
   "dependencies": {
+    "elm": "^0.18.0",
     "simple-line-icons": "^2.4.1"
   }
 }

--- a/frontend/static/index.js
+++ b/frontend/static/index.js
@@ -1,4 +1,4 @@
-window.addEventListener('load', function() {
+window.addEventListener('load', function () {
 
     var app
     var tokenRenewalTimeout
@@ -32,7 +32,7 @@ window.addEventListener('load', function() {
         var delay = expiresAt - Date.now()
 
         if (delay > 0) {
-            tokenRenewalTimeout = setTimeout(function() {
+            tokenRenewalTimeout = setTimeout(function () {
                 renewToken()
             }, delay)
         }
@@ -62,13 +62,17 @@ window.addEventListener('load', function() {
             url: url
         })
 
-        app.ports.login.subscribe(function() {
+        app.ports.login.subscribe(function () {
             webAuth.authorize()
-        })
+        });
+
+        app.ports.logPort.subscribe(function (args) {
+            console.log(args);
+        });
     }
 
     function handleAuthentication() {
-        webAuth.parseHash({ hash: window.location.hash }, function(err, authResult) {
+        webAuth.parseHash({ hash: window.location.hash }, function (err, authResult) {
             if (authResult && authResult.idToken) {
                 console.log('Start with newly created token')
                 setSession(authResult)


### PR DESCRIPTION
## Bakgrunn 
For en stund siden trynte panopticon.cloud.vy.no, dvs siden var helt blank. Dette skyldtes at dekoderen for `/status`-kallet feilet fordi det kom noe uforventet data fra `itinerary`-mikrotjenesten. Feilen fra `itinerary` ble fikset, men vi så samtidig behovet for at panopticon ikke bør tryne hvis én tjeneste leverer rar data. 

## Løsning 
Gjør dekoderen av `/status`-responsen mer robust, ved å godta at feltene er `null` og bare printe teksten "null" i disse tilfellene. 

Dersom dekoderen skulle tryne så vil feilmeldingen logges til konsollen slik at man ser hva som gikk galt. Bør det også trigges en alarm, eller er det unødvendig❓ 