### PR TITLE
✨ Add WARN as status to SingleCallSensor

### DIFF
--- a/client/src/main/java/pro/panopticon/client/sensor/impl/SingleCallSensor.java
+++ b/client/src/main/java/pro/panopticon/client/sensor/impl/SingleCallSensor.java
@@ -33,6 +33,10 @@ public class SingleCallSensor implements Sensor {
         measurements.compute(alertInfo, (k, v) -> Status.ERROR);
     }
 
+    public void triggerWarn(AlertInfo alertInfo) {
+        measurements.compute(alertInfo, (k, v) -> Status.WARN);
+    }
+    
     public void triggerOk(AlertInfo alertInfo) {
         measurements.compute(alertInfo, (k, v) -> Status.OK);
     }
@@ -41,6 +45,8 @@ public class SingleCallSensor implements Sensor {
         switch (status) {
             case ERROR:
                 return "ERROR";
+            case WARN:
+                return "WARN";
             case OK:
                 return "INFO";
             default:
@@ -49,13 +55,18 @@ public class SingleCallSensor implements Sensor {
     }
 
     private String getDisplayValue(Status status) {
-        if (status == Status.ERROR) {
-            return "In error";
+        switch(status) {
+            case ERROR:
+                return "In error";
+            case WARN:
+                return "Status: WARN";
+            case OK:
+            default:
+                return "Status: OK";
         }
-        return "Status: OK";
     }
 
     private enum Status {
-        OK, ERROR
+        OK, WARN, ERROR
     }
 }


### PR DESCRIPTION
Vi bruker stort sett SingleCallSensor rundt periodiske jobber som oppdatering av cache osv. Dersom en cache ikke klarer å hentes ned ved oppstart er dette kritisk, men etter oppstart kan man som oftest leve med noe utdatert data. Jeg har derfor savnet muligheten til å kunne trigge en WARN om at oppdateringen av cachen gikk galt så lenge vi har data, men med en gang vi ikke har data trigge en ERROR.

## Eksempel:

```kt
fun updateCache() {
    try {
        // ...
        sensor.triggerOk(alertInfo)
    } catch(ex: Exception) {
        if(cache.isEmpty()) {
            sensor.triggerError(alertInfo)
        } else {
            sensor.triggerWarn(alertInfo)
        }
    }
}
```
Alternativt:
```kt
if(timeSinceLastOk > 5minutes) {
    sensor.triggerError(alertInfo)
} else {
    sensor.triggerWarn(alertInfo)
}
```


<img width="589" alt="Screenshot 2021-05-13 at 12 51 27" src="https://user-images.githubusercontent.com/57355800/118117153-84b3e280-b3eb-11eb-89d7-4566e613465c.png">


Her burde vi også få fikset sånn at gule noder kommer over grønne ☝️