### PR TITLE
Add cloudwatch link

### DIFF
--- a/backend/src/main/java/no/panopticon/alerters/StatusAlerter.java
+++ b/backend/src/main/java/no/panopticon/alerters/StatusAlerter.java
@@ -83,7 +83,9 @@ public class StatusAlerter {
                 toAlert.add(new SlackClient.Line(
                         highestSeverity,
                         createHeader(m),
-                        createMessage(m)
+                        createMessage(m),
+                        m.getKey(),
+                        m.getValue().isEmpty() ? null : m.getValue().get(0).runningUnit.getComponent()
                 ));
             }
         });

--- a/backend/src/main/java/no/panopticon/integrations/cloudwatch/CloudWatchUrlUtils.java
+++ b/backend/src/main/java/no/panopticon/integrations/cloudwatch/CloudWatchUrlUtils.java
@@ -1,0 +1,66 @@
+package no.panopticon.integrations.cloudwatch;
+
+import org.springframework.stereotype.Component;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CloudWatchUrlUtils {
+    private static final String BASE_URL = "https://eu-central-1.console.aws.amazon.com/cloudwatch/home?region=eu-central-1";
+
+    private static final Map<String, String> LOG_GROUP_MAP  = new HashMap<String, String>() {{
+        put("booking", "/aws/elasticbeanstalk/vy-booking-prod/var/log/eb-docker/containers/eb-current-app/stdouterr.log");
+        put("deviation", "/aws/elasticbeanstalk/vy-deviation-prod/var/log/eb-docker/containers/eb-current-app/stdouterr.log");
+        put("entertainment", "/aws/elasticbeanstalk/vy-entertainment-prod/var/log/eb-docker/containers/eb-current-app/stdouterr.log");
+        put("itinerary", "/aws/elasticbeanstalk/vy-itinerary-prod/var/log/eb-docker/containers/eb-current-app/stdouterr.log");
+        put("location", "/aws/elasticbeanstalk/vy-location-prod/var/log/eb-docker/containers/eb-current-app/stdouterr.log");
+        put("loyalty", "/aws/lambda/prod-loyalty-s3-listener-lambda");
+        put("notification", "/aws/elasticbeanstalk/vy-notification-prod/var/log/eb-docker/containers/eb-current-app/stdouterr.log");
+        put("pdfTicket", "/aws/elasticbeanstalk/vy-pdf-ticket-prod/var/log/eb-docker/containers/eb-current-app/stdouterr.log");
+        put("seat", "/aws/elasticbeanstalk/vy-seat-prod/var/log/eb-docker/containers/eb-current-app/stdouterr.log");
+        put("taxi", "/aws/elasticbeanstalk/vy-taxi-prod/var/log/web-1.log");
+        put("ticket", "/aws/elasticbeanstalk/nsb-ticket-prod/var/log/eb-docker/containers/eb-current-app/stdouterr.log");
+        put("user", "/aws/elasticbeanstalk/nsb-user-prod/var/log/web-1.log");
+        put("user-data", "/aws/elasticbeanstalk/nsb-user-data-prod/var/log/web-1.log");
+    }};
+
+    /** Gets a custom CloudWatch URL for a given component and search string */
+    public static String getCloudWatchUrl(String component, String searchString) {
+        return String.format(
+                "%s#logsV2:log-groups/log-group/%s/log-events%s",
+                BASE_URL,
+                getLogGroup(component),
+                getFilterOptions(searchString)
+        );
+    }
+
+    /** Gets the correct URL for a given log group
+     *
+     * This function runs the URL encoding algorithm twice and replaces all % with $. This is the way CloudWatch URLs
+     * are generated for some reason.
+     * */
+    private static String getLogGroup(String component) {
+        return urlEncodeString(
+                urlEncodeString(
+                        LOG_GROUP_MAP.getOrDefault(component, "/aws/elasticbeanstalk")
+                )
+            ).replaceAll("%", "\\$");
+    }
+
+    private static String getFilterOptions(String searchString) {
+        return urlEncodeString("?start=-3600000&filterPattern=" + searchString)
+                .replaceAll("%", "\\$");
+    }
+
+    private static String urlEncodeString(String original) {
+        try {
+            return URLEncoder.encode(original, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            return original;
+        }
+    }
+}
+

--- a/backend/src/main/java/no/panopticon/integrations/slack/SlackClient.java
+++ b/backend/src/main/java/no/panopticon/integrations/slack/SlackClient.java
@@ -94,7 +94,12 @@ public class SlackClient {
 
         SlackChannel channel = slack.findChannelByName(slackConfiguration.channel);
 
-        String heading = String.format("*%d målepunkter med feil akkurat nå. Se detaljert hendelseslogg i #%s*", alertLines.size(), slackConfiguration.channelDetailed);
+        String heading = String.format(
+                "*%d %s med feil akkurat nå. Se detaljert hendelseslogg i #%s*",
+                alertLines.size(),
+                alertLines.size() == 1 ? "målepunkt" : "målepunkter",
+                slackConfiguration.channelDetailed
+        );
 
         List<SlackAttachment> attachments = alertLines.stream().map(l -> {
             SlackAttachment a = new SlackAttachment(

--- a/backend/src/main/java/no/panopticon/integrations/slack/SlackClient.java
+++ b/backend/src/main/java/no/panopticon/integrations/slack/SlackClient.java
@@ -5,6 +5,7 @@ import com.ullink.slack.simpleslackapi.impl.SlackSessionFactory;
 import com.ullink.slack.simpleslackapi.replies.SlackMessageReply;
 import no.panopticon.alerters.MissingRunningUnitsAlerter;
 import no.panopticon.config.SlackConfiguration;
+import no.panopticon.integrations.cloudwatch.CloudWatchUrlUtils;
 import no.panopticon.storage.RunningUnit;
 import no.panopticon.storage.StatusSnapshot;
 import org.slf4j.Logger;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
@@ -95,12 +97,22 @@ public class SlackClient {
         String heading = String.format("*%d målepunkter med feil akkurat nå. Se detaljert hendelseslogg i #%s*", alertLines.size(), slackConfiguration.channelDetailed);
 
         List<SlackAttachment> attachments = alertLines.stream().map(l -> {
-            SlackAttachment a = new SlackAttachment(l.header, null, l.message, null);
+            SlackAttachment a = new SlackAttachment(
+                    l.header,
+                    null,
+                    String.format(
+                            "%s\n\n<%s|Se logger i CloudWatch>",
+                            l.message,
+                            CloudWatchUrlUtils.getCloudWatchUrl(l.component, l.alertKey)
+                    ),
+                    null
+            );
             if (l.severity.equals("ERROR")) {
                 a.setColor(RED);
             } else if (l.severity.equals("WARN")) {
                 a.setColor(YELLOW);
             }
+            a.addMarkdownIn("text");
             return a;
         }).collect(toList());
 
@@ -144,11 +156,15 @@ public class SlackClient {
         private final String severity;
         private final String header;
         private final String message;
+        private final String component;
+        private final String alertKey;
 
-        public Line(String severity, String header, String message) {
+        public Line(String severity, String header, String message, String component, String alertKey) {
             this.severity = severity;
             this.header = header;
             this.message = message;
+            this.component = component;
+            this.alertKey = alertKey;
         }
 
         @Override


### PR DESCRIPTION
This pull request adds a link to see any relevant logs in CloudWatch:

![image](https://user-images.githubusercontent.com/1307267/120196342-0bf0bb00-c220-11eb-9109-1ff25a63e71c.png)

The hard part here was understanding the way the CloudWatch URLs are formatted and encoded - not super intuitive.

This PR also fixes a pluralization error.