### PR TITLE
✨ Generell sensor for å overvåke threadpools

### DIFF
--- a/client/src/main/java/pro/panopticon/client/sensor/impl/ThreadPoolSensor.kt
+++ b/client/src/main/java/pro/panopticon/client/sensor/impl/ThreadPoolSensor.kt
@@ -1,0 +1,37 @@
+package pro.panopticon.client.sensor.impl
+
+import com.amazonaws.services.cloudwatch.model.StandardUnit
+import pro.panopticon.client.model.Measurement
+import pro.panopticon.client.sensor.Sensor
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ThreadPoolExecutor
+
+class ThreadPoolSensor : Sensor {
+    private val threadPools = ConcurrentHashMap<String, ThreadPoolExecutor>()
+
+    fun register(key: String, threadPool: ThreadPoolExecutor) {
+        threadPools[key] = threadPool
+    }
+
+    override fun measure(): List<Measurement> {
+        return threadPools.entries.flatMap { (key, threadPool) ->
+            mutableListOf(
+                createMeasurement("$key.threadpool.poolsize", threadPool.poolSize),
+                createMeasurement("$key.threadpool.largestpoolsize", threadPool.largestPoolSize),
+                createMeasurement("$key.threadpool.activecount", threadPool.activeCount),
+                createMeasurement("$key.threadpool.taskcount", threadPool.taskCount),
+                createMeasurement("$key.threadpool.completedcount", threadPool.completedTaskCount),
+            )
+        }
+    }
+
+    private fun createMeasurement(key: String, value: Number): Measurement {
+        return Measurement(
+            key,
+            "INFO",
+            value.toString(),
+            Measurement.CloudwatchValue(value.toDouble(), StandardUnit.Count),
+            ""
+        )
+    }
+}


### PR DESCRIPTION
## Bruk
```kt
@Service
class TravelPlannerService(
   // ...
   private val threadPoolSensor: ThreadPoolSensor,
) {
    private val threadPool = Executors.newCachedThreadPool()
        .also { threadPoolSensor.register("travelplanner", it as ThreadPoolExecutor) }
}
```

## Resultat
<img width="301" alt="Screenshot 2021-06-23 at 11 30 29" src="https://user-images.githubusercontent.com/57355800/123076248-3d246b80-d419-11eb-80aa-59141afef748.png">
<img width="303" alt="Screenshot 2021-06-23 at 11 30 07" src="https://user-images.githubusercontent.com/57355800/123076258-3eee2f00-d419-11eb-87c7-b54b27a4b22e.png">
