### PR TITLE
Log values which failed transmission.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -94,35 +94,39 @@
             <version>1.7.21</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
+            <artifactId>kotlin-test-junit</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
+
         <dependency>
             <groupId>io.github.microutils</groupId>
             <artifactId>kotlin-logging</artifactId>
             <version>1.7.9</version>
             <scope>compile</scope>
         </dependency>
-
 
     </dependencies>
 
@@ -163,6 +167,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <executions>
                     <execution>
                         <id>compile</id>

--- a/client/src/main/java/pro/panopticon/client/PanopticonClient.kt
+++ b/client/src/main/java/pro/panopticon/client/PanopticonClient.kt
@@ -105,8 +105,15 @@ class PanopticonClient(
                         .withDimensions(cloudwatchValue.dimensions)
                 }
             }
+
         if (cloudwatchClient != null && hasCloudwatchConfig != null && hasCloudwatchConfig.sensorStatisticsEnabled()) {
-            cloudwatchClient.sendStatistics(namespace, statistics)
+            try {
+                cloudwatchClient.sendStatistics(namespace, statistics)
+            } catch (e: Exception) {
+                val statsAsJson = OBJECT_MAPPER.writeValueAsString(statistics)
+                LOG.error { "Failed to send the following statistics to Cloudwatch: $statsAsJson" }
+                throw e;
+            }
         }
     }
 

--- a/client/src/test/java/pro/panopticon/client/sensor/impl/SingleCallSensorTest.kt
+++ b/client/src/test/java/pro/panopticon/client/sensor/impl/SingleCallSensorTest.kt
@@ -29,7 +29,7 @@ class SingleCallSensorTest {
         sensor.triggerError(Sensor.AlertInfo("123", ALARM_DESCRIPTION))
         val measurements = sensor.measure()
         val measurement = getMeasurementFromList(measurements, "123")
-        Assert.assertEquals("Measurement has error status", "ERROR", measurement.status)
+        Assert.assertEquals("Measurement has error status", Measurement.Status.ERROR, measurement.status)
     }
 
     @Test
@@ -59,7 +59,7 @@ class SingleCallSensorTest {
         sensor.triggerOk(Sensor.AlertInfo("123", ALARM_DESCRIPTION))
         val measurements = sensor.measure()
         val measurement = getMeasurementFromList(measurements, "123")
-        Assert.assertEquals("Measurement has info status", "INFO", measurement.status)
+        Assert.assertEquals("Measurement has info status", Measurement.Status.INFO, measurement.status)
     }
 
     @Test
@@ -69,7 +69,7 @@ class SingleCallSensorTest {
         sensor.triggerError(Sensor.AlertInfo("123", ALARM_DESCRIPTION))
         val measurements = sensor.measure()
         val measurement = getMeasurementFromList(measurements, "123")
-        Assert.assertEquals("Measurement has error status", "ERROR", measurement.status)
+        Assert.assertEquals("Measurement has error status", Measurement.Status.ERROR, measurement.status)
     }
 
     private fun getMeasurementFromList(measurements: List<Measurement>, key: String): Measurement {

--- a/client/src/test/java/pro/panopticon/client/sensor/impl/SuccessrateSensorTest.kt
+++ b/client/src/test/java/pro/panopticon/client/sensor/impl/SuccessrateSensorTest.kt
@@ -20,7 +20,7 @@ class SuccessrateSensorTest {
         Assert.assertThat(measurements.size, Is.`is`(1))
         val key1 = measurements.stream().filter { m: Measurement -> m.key == "key1" }.findAny()
         Assert.assertThat(key1.isPresent, Is.`is`(true))
-        Assert.assertThat(key1.get().status, Is.`is`("INFO"))
+        Assert.assertThat(key1.get().status, Is.`is`(Measurement.Status.INFO))
         Assert.assertThat(key1.get().displayValue, StringContains.containsString("Last 2 calls: 1 success, 1 failure"))
         Assert.assertThat(key1.get().displayValue,
             StringContains.containsString("not enough calls to report status yet"))
@@ -34,7 +34,7 @@ class SuccessrateSensorTest {
         Assert.assertThat(measurements.size, Is.`is`(1))
         val key1 = measurements.stream().filter { m: Measurement -> m.key == "key1" }.findAny()
         Assert.assertThat(key1.isPresent, Is.`is`(true))
-        Assert.assertThat(key1.get().status, Is.`is`("INFO"))
+        Assert.assertThat(key1.get().status, Is.`is`(Measurement.Status.INFO))
         Assert.assertThat(key1.get().displayValue,
             StringContains.containsString("Last 100 calls: 100 success, 0 failure"))
     }
@@ -48,7 +48,7 @@ class SuccessrateSensorTest {
         Assert.assertThat(measurements.size, Is.`is`(1))
         val key1 = measurements.stream().filter { m: Measurement -> m.key == "key1" }.findAny()
         Assert.assertThat(key1.isPresent, Is.`is`(true))
-        Assert.assertThat(key1.get().status, Is.`is`("WARN"))
+        Assert.assertThat(key1.get().status, Is.`is`(Measurement.Status.WARN))
         Assert.assertThat(key1.get().displayValue,
             StringContains.containsString("Last 100 calls: 90 success, 10 failure"))
     }
@@ -62,7 +62,7 @@ class SuccessrateSensorTest {
         Assert.assertThat(measurements.size, Is.`is`(1))
         val key1 = measurements.stream().filter { m: Measurement -> m.key == "key1" }.findAny()
         Assert.assertThat(key1.isPresent, Is.`is`(true))
-        Assert.assertThat(key1.get().status, Is.`is`("ERROR"))
+        Assert.assertThat(key1.get().status, Is.`is`(Measurement.Status.ERROR))
         Assert.assertThat(key1.get().displayValue,
             StringContains.containsString("Last 100 calls: 80 success, 20 failure"))
     }
@@ -75,7 +75,7 @@ class SuccessrateSensorTest {
         Assert.assertThat(measurements.size, Is.`is`(1))
         val key1 = measurements.stream().filter { m: Measurement -> m.key == "key1" }.findAny()
         Assert.assertThat(key1.isPresent, Is.`is`(true))
-        Assert.assertThat(key1.get().status, Is.`is`("INFO"))
+        Assert.assertThat(key1.get().status, Is.`is`(Measurement.Status.INFO))
         Assert.assertThat(key1.get().displayValue,
             StringContains.containsString("Last 100 calls: 0 success, 100 failure"))
     }
@@ -89,7 +89,7 @@ class SuccessrateSensorTest {
         Assert.assertThat(measurements.size, Is.`is`(1))
         val key1 = measurements.stream().filter { m: Measurement -> m.key == "key1" }.findAny()
         Assert.assertThat(key1.isPresent, Is.`is`(true))
-        Assert.assertThat(key1.get().status, Is.`is`("INFO"))
+        Assert.assertThat(key1.get().status, Is.`is`(Measurement.Status.INFO))
         Assert.assertThat(key1.get().displayValue,
             StringContains.containsString("Last 100 calls: 100 success, 0 failure"))
     }
@@ -105,12 +105,12 @@ class SuccessrateSensorTest {
         Assert.assertThat(measurements.size, Is.`is`(2))
         val key1 = measurements.stream().filter { m: Measurement -> m.key == "key1" }.findAny()
         Assert.assertThat(key1.isPresent, Is.`is`(true))
-        Assert.assertThat(key1.get().status, Is.`is`("ERROR"))
+        Assert.assertThat(key1.get().status, Is.`is`(Measurement.Status.ERROR))
         Assert.assertThat(key1.get().displayValue,
             StringContains.containsString("Last 100 calls: 50 success, 50 failure"))
         val key2 = measurements.stream().filter { m: Measurement -> m.key == "key2" }.findAny()
         Assert.assertThat(key2.isPresent, Is.`is`(true))
-        Assert.assertThat(key2.get().status, Is.`is`("INFO"))
+        Assert.assertThat(key2.get().status, Is.`is`(Measurement.Status.INFO))
         Assert.assertThat(key2.get().displayValue,
             StringContains.containsString("Last 100 calls: 98 success, 2 failure"))
     }
@@ -135,7 +135,7 @@ class SuccessrateSensorTest {
         IntStream.range(0, 50).forEach { sensor.tickSuccess(Sensor.AlertInfo("key1", "description")) }
         val measurements = sensor.measure()
         val key1 = measurements.stream().filter { m: Measurement -> m.key == "key1" }.findAny()
-        Assert.assertThat(key1.get().status, Is.`is`("INFO"))
+        Assert.assertThat(key1.get().status, Is.`is`(Measurement.Status.INFO))
     }
 
     internal inner class NowSupplierMock : NowSupplier {


### PR DESCRIPTION
Dersom vi ikke klarer å sende verdier til cloudwatch, så får vi lite hjelp av den eksisterende feilmeldingen. Endrer koden slik at dataen som trigger feilen logges, slik at det blir lettere å finne og fikse feilen i fremtiden.